### PR TITLE
FEAT: implementa permisos RBAC por rol

### DIFF
--- a/backend/apps/users/permissions.py
+++ b/backend/apps/users/permissions.py
@@ -1,0 +1,33 @@
+from rest_framework.permissions import BasePermission
+
+from .models import User
+
+
+class RolePermission(BasePermission):
+    """Base permission for endpoints restricted by application role."""
+
+    recognized_roles = frozenset(User.Role.values)
+    allowed_roles = frozenset()
+
+    def has_permission(self, request, view):
+        user = getattr(request, "user", None)
+        if user is None or not getattr(user, "is_authenticated", False):
+            return False
+
+        role = getattr(user, "role", None)
+        if role not in self.recognized_roles:
+            return False
+
+        return role == User.Role.ADMIN or role in self.allowed_roles
+
+
+class IsTester(RolePermission):
+    allowed_roles = frozenset({User.Role.TESTER})
+
+
+class IsClient(RolePermission):
+    allowed_roles = frozenset({User.Role.CLIENT})
+
+
+class IsAdmin(RolePermission):
+    allowed_roles = frozenset({User.Role.ADMIN})

--- a/backend/apps/users/tests.py
+++ b/backend/apps/users/tests.py
@@ -1,3 +1,85 @@
-from django.test import TestCase
+from types import SimpleNamespace
 
-# Create your tests here.
+from django.test import SimpleTestCase
+
+from .models import User
+from .permissions import IsAdmin, IsClient, IsTester
+
+
+class RolePermissionTests(SimpleTestCase):
+    permission_classes = (IsTester, IsClient, IsAdmin)
+
+    @staticmethod
+    def request_with_user(**user_attributes):
+        return SimpleNamespace(user=SimpleNamespace(**user_attributes))
+
+    def assert_all_permissions_denied(self, request):
+        for permission_class in self.permission_classes:
+            with self.subTest(permission=permission_class.__name__):
+                self.assertFalse(permission_class().has_permission(request, None))
+
+    def test_request_without_user_is_denied(self):
+        self.assert_all_permissions_denied(SimpleNamespace())
+
+    def test_anonymous_user_is_denied(self):
+        request = self.request_with_user(is_authenticated=False)
+
+        self.assert_all_permissions_denied(request)
+
+    def test_unauthenticated_user_is_denied(self):
+        request = self.request_with_user(
+            is_authenticated=False,
+            role=User.Role.TESTER,
+        )
+
+        self.assert_all_permissions_denied(request)
+
+    def test_user_without_role_is_denied(self):
+        request = self.request_with_user(is_authenticated=True)
+
+        self.assert_all_permissions_denied(request)
+
+    def test_none_role_is_denied(self):
+        request = self.request_with_user(is_authenticated=True, role=None)
+
+        self.assert_all_permissions_denied(request)
+
+    def test_empty_role_is_denied(self):
+        request = self.request_with_user(is_authenticated=True, role="")
+
+        self.assert_all_permissions_denied(request)
+
+    def test_tester_permissions(self):
+        request = self.request_with_user(
+            is_authenticated=True,
+            role=User.Role.TESTER,
+        )
+
+        self.assertTrue(IsTester().has_permission(request, None))
+        self.assertFalse(IsClient().has_permission(request, None))
+        self.assertFalse(IsAdmin().has_permission(request, None))
+
+    def test_client_permissions(self):
+        request = self.request_with_user(
+            is_authenticated=True,
+            role=User.Role.CLIENT,
+        )
+
+        self.assertFalse(IsTester().has_permission(request, None))
+        self.assertTrue(IsClient().has_permission(request, None))
+        self.assertFalse(IsAdmin().has_permission(request, None))
+
+    def test_admin_permissions(self):
+        request = self.request_with_user(
+            is_authenticated=True,
+            role=User.Role.ADMIN,
+        )
+
+        self.assertTrue(IsTester().has_permission(request, None))
+        self.assertTrue(IsClient().has_permission(request, None))
+        self.assertTrue(IsAdmin().has_permission(request, None))
+
+    def test_unknown_role_is_denied(self):
+        request = self.request_with_user(is_authenticated=True, role="UNKNOWN")
+
+        self.assert_all_permissions_denied(request)


### PR DESCRIPTION
Cambios
Se agrega una base reutilizable de permisos por rol usando Django REST Framework.
Se implementan los permisos:
RolePermission
IsTester
IsClient
IsAdmin
Los permisos utilizan User.Role como fuente única de verdad para los roles definidos en el modelo.
Se valida que usuarios no autenticados, sin rol o con roles inválidos no puedan acceder.
El rol ADMIN funciona como bypass para los permisos de negocio.
Tests
Se agregan tests unitarios para validar:
acceso de TESTER
acceso de CLIENT
acceso de ADMIN
usuarios no autenticados
usuarios sin rol
roles vacíos o inválidos
Resultado:
10 tests
OK
Alcance

Este PR cubre únicamente la base de control de roles del Issue #3.

La aplicación de estos permisos sobre endpoints específicos se realizará a medida que los endpoints correspondientes sean implementados e integrados en develop.