### PR TITLE
FEAT: implementación de serializers en users

### DIFF
--- a/backend/apps/users/serializers.py
+++ b/backend/apps/users/serializers.py
@@ -1,0 +1,131 @@
+from django.contrib.auth import authenticate
+from django.contrib.auth.password_validation import validate_password
+
+from rest_framework import serializers
+
+from .models import User
+
+
+class RegisterSerializer(serializers.ModelSerializer):
+
+    password = serializers.CharField(
+        write_only=True,
+        min_length=8,
+        validators=[validate_password]
+    )
+
+    class Meta:
+        model = User
+
+        fields = [
+            "email",
+            "password",
+            "name",
+            "surname",
+            "dni",
+            "phone",
+            "sex",
+            "date_of_birth",
+            "zona",
+        ]
+
+        extra_kwargs = {
+            "email": { "required": True, },
+
+            "name": { "required": True, },
+
+            "surname": { "required": True, },
+
+            "zona": { "required": True, "allow_blank": False, },
+
+            "dni": { "required": False, "allow_null": True, "allow_blank": True, },
+
+            "phone": { "required": False, "allow_blank": True, },
+
+            "sex": { "required": False, "allow_blank": True, },
+
+            "date_of_birth": { "required": False, "allow_null": True, },
+        }
+
+    def validate_email(self, value):
+
+        value = value.strip().lower()
+
+        if User.objects.filter(email__iexact=value).exists():
+            raise serializers.ValidationError(
+                "No se pudo completar el registro."
+            )
+
+        return value
+
+    def create(self, validated_data):
+
+        password = validated_data.pop("password")
+
+        return User.objects.create_user(
+            password=password,
+            role=User.Role.CLIENT,
+            **validated_data,
+        )
+
+
+class LoginSerializer(serializers.Serializer):
+
+    email = serializers.EmailField()
+    password = serializers.CharField(write_only=True)
+
+    def validate(self, data):
+        email = data["email"].strip().lower()
+
+        user = authenticate(
+            request=self.context.get("request"),
+            username=email,
+            password=data["password"],
+        )
+
+        if user is None:
+            raise serializers.ValidationError(
+                "Credenciales inválidas."
+            )
+
+        if not user.is_active:
+            raise serializers.ValidationError(
+                "No se pudo completar el inicio de sesión."
+            )
+
+        data["user"] = user
+
+        return data
+
+
+class UserSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = User
+
+        fields = [
+            "id",
+            "email",
+            "name",
+            "surname",
+            "dni",
+            "phone",
+            "sex",
+            "date_of_birth",
+            "zona",
+            "role",
+            "reputation",
+            "date_joined",
+            "created_at",
+            "updated_at",
+        ]
+
+        read_only_fields = [
+            "id",
+            "email",
+            "role",
+            "reputation",
+            "date_joined",
+            "created_at",
+            "updated_at",
+        ]

--- a/backend/apps/users/test_serializers.py
+++ b/backend/apps/users/test_serializers.py
@@ -1,0 +1,192 @@
+from datetime import date
+
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from .serializers import RegisterSerializer, UserSerializer
+
+
+User = get_user_model()
+
+
+class RegisterSerializerTests(TestCase):
+
+    def valid_payload(self):
+        return {
+            "email": "test@example.com",
+            "password": "StrongPassword123!",
+            "name": "Test",
+            "surname": "User",
+            "zona": "Buenos Aires",
+        }
+
+    def test_valid_data_creates_user(self):
+        serializer = RegisterSerializer(data=self.valid_payload())
+
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+
+        user = serializer.save()
+
+        self.assertEqual(user.email, "test@example.com")
+        self.assertEqual(user.name, "Test")
+        self.assertEqual(user.surname, "User")
+        self.assertEqual(user.zona, "Buenos Aires")
+
+    def test_role_is_assigned_by_backend(self):
+        payload = self.valid_payload()
+        payload["role"] = User.Role.ADMIN
+
+        serializer = RegisterSerializer(data=payload)
+
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+
+        user = serializer.save()
+
+        self.assertEqual(user.role, User.Role.CLIENT)
+
+    def test_client_cannot_control_internal_fields(self):
+        payload = self.valid_payload()
+        payload.update(
+            {
+                "role": User.Role.ADMIN,
+                "reputation": "99.99",
+                "is_staff": True,
+                "is_superuser": True,
+                "is_active": False,
+                "date_joined": date(2026, 1, 1),
+                "created_at": date(2026, 1, 1),
+                "updated_at": date(2026, 1, 1),
+            }
+        )
+
+        serializer = RegisterSerializer(data=payload)
+
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+
+        user = serializer.save()
+
+        self.assertEqual(user.role, User.Role.CLIENT)
+        self.assertEqual(user.reputation, 0)
+        self.assertFalse(user.is_staff)
+        self.assertFalse(user.is_superuser)
+        self.assertTrue(user.is_active)
+
+    def test_password_is_hashed(self):
+        serializer = RegisterSerializer(data=self.valid_payload())
+
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+
+        user = serializer.save()
+
+        self.assertNotEqual(user.password, "StrongPassword123!")
+        self.assertTrue(user.check_password("StrongPassword123!"))
+
+    def test_password_is_write_only(self):
+        serializer = RegisterSerializer()
+
+        self.assertTrue(serializer.fields["password"].write_only)
+
+    def test_duplicate_email_is_rejected(self):
+        User.objects.create_user(
+            email="test@example.com",
+            password="StrongPassword123!",
+            name="Existing",
+            surname="User",
+            zona="Buenos Aires",
+            role=User.Role.CLIENT,
+        )
+
+        serializer = RegisterSerializer(data=self.valid_payload())
+
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("email", serializer.errors)
+
+    def test_invalid_password_is_rejected(self):
+        payload = self.valid_payload()
+        payload["password"] = "password"
+
+        serializer = RegisterSerializer(data=payload)
+
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("password", serializer.errors)
+
+    def test_required_fields_are_validated(self):
+        payload = {
+            "email": "test@example.com",
+            "password": "StrongPassword123!",
+        }
+
+        serializer = RegisterSerializer(data=payload)
+
+        self.assertFalse(serializer.is_valid())
+
+        self.assertIn("name", serializer.errors)
+        self.assertIn("surname", serializer.errors)
+        self.assertIn("zona", serializer.errors)
+
+    def test_optional_fields_can_be_omitted(self):
+        serializer = RegisterSerializer(data=self.valid_payload())
+
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+
+    def test_duplicate_dni_is_rejected(self):
+        User.objects.create_user(
+            email="existing@example.com",
+            password="StrongPassword123!",
+            name="Existing",
+            surname="User",
+            dni="12345678",
+            zona="Buenos Aires",
+            role=User.Role.CLIENT,
+        )
+
+        payload = self.valid_payload()
+        payload["dni"] = "12345678"
+
+        serializer = RegisterSerializer(data=payload)
+
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("dni", serializer.errors)
+
+
+class UserSerializerTests(TestCase):
+
+    def setUp(self):
+        self.user = User.objects.create_user(
+            email="test@example.com",
+            password="StrongPassword123!",
+            name="Test",
+            surname="User",
+            zona="Buenos Aires",
+            role=User.Role.CLIENT,
+            reputation=0,
+        )
+
+    def test_password_is_not_exposed(self):
+        serializer = UserSerializer(instance=self.user)
+
+        self.assertNotIn("password", serializer.data)
+
+    def test_zone_is_writable(self):
+        serializer = UserSerializer(
+            instance=self.user,
+            data={"zona": "Córdoba"},
+            partial=True,
+        )
+
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+
+        user = serializer.save()
+
+        self.assertEqual(user.zona, "Córdoba")
+
+    def test_protected_fields_are_read_only(self):
+        serializer = UserSerializer()
+
+        read_only_fields = serializer.Meta.read_only_fields
+
+        self.assertIn("role", read_only_fields)
+        self.assertIn("reputation", read_only_fields)
+        self.assertIn("date_joined", read_only_fields)
+        self.assertIn("created_at", read_only_fields)
+        self.assertIn("updated_at", read_only_fields)


### PR DESCRIPTION
Implementa los serializers de usuarios correspondientes a la subissue #40.

Cambios
Implementa RegisterSerializer.
Implementa LoginSerializer.
Implementa UserSerializer.
Normaliza y valida el email.
Aplica los validadores de contraseña configurados en Django.
Utiliza create_user() para garantizar el hashing de la contraseña.
Asigna el rol inicial desde el backend.
No permite que el cliente controle role ni campos internos de seguridad.
No expone password en UserSerializer.
Permite modificar zona desde el perfil.
Mantiene role, reputation y fechas internas como campos de solo lectura.
Agrega pruebas específicas para los serializers.
Reglas de seguridad

El rol inicial se asigna exclusivamente desde backend.