### PR TITLE
Feat: implementa aprobación y rechazo de proyectos

### DIFF
--- a/backend/apps/projects/serializers.py
+++ b/backend/apps/projects/serializers.py
@@ -28,3 +28,19 @@ class ProjectSerializer(serializers.ModelSerializer):
             'updated_at',
             'finalized_at',
         ]
+
+
+class ProjectStatusSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Project
+        fields = ['state']
+
+    def validate_state(self, value):
+        allowed_states = ['OPEN', 'REJECTED']
+
+        if value not in allowed_states:
+            raise serializers.ValidationError(
+                'The state must be OPEN or REJECTED.'
+            )
+
+        return value

--- a/backend/apps/projects/tests.py
+++ b/backend/apps/projects/tests.py
@@ -91,3 +91,143 @@ class ProjectCreateTests(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertFalse(Project.objects.exists())
+
+
+class ProjectStatusUpdateTests(APITestCase):
+    def setUp(self):
+        self.client_user = User.objects.create_user(
+            email='client-status@example.com',
+            password='test-password',
+            name='Client',
+            surname='User',
+            role=User.Role.CLIENT,
+        )
+        self.tester_user = User.objects.create_user(
+            email='tester-status@example.com',
+            password='test-password',
+            name='Tester',
+            surname='User',
+            role=User.Role.TESTER,
+        )
+        self.admin_user = User.objects.create_user(
+            email='admin@example.com',
+            password='test-password',
+            name='Admin',
+            surname='User',
+            role=User.Role.ADMIN,
+        )
+        self.project = Project.objects.create(
+            title='FinTech Mobile App',
+            description='Application for financial transactions.',
+            repository='https://github.com/example/fintech-app',
+            demo_url='https://example.com/fintech-app',
+            technologies='Flutter, Node.js, Firebase',
+            modality='REMOTE',
+            client=self.client_user,
+        )
+        self.url = reverse(
+            'project-status-update',
+            kwargs={'pk': self.project.pk},
+        )
+
+    def test_admin_can_approve_pending_project(self):
+        self.client.force_authenticate(user=self.admin_user)
+
+        response = self.client.patch(
+            self.url,
+            {'state': 'OPEN'},
+            format='json',
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.project.refresh_from_db()
+        self.assertEqual(self.project.state, 'OPEN')
+
+    def test_admin_can_reject_pending_project(self):
+        self.client.force_authenticate(user=self.admin_user)
+
+        response = self.client.patch(
+            self.url,
+            {'state': 'REJECTED'},
+            format='json',
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.project.refresh_from_db()
+        self.assertEqual(self.project.state, 'REJECTED')
+
+    def test_client_cannot_update_project_status(self):
+        self.client.force_authenticate(user=self.client_user)
+
+        response = self.client.patch(
+            self.url,
+            {'state': 'OPEN'},
+            format='json',
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.project.refresh_from_db()
+        self.assertEqual(self.project.state, 'PENDING')
+
+    def test_tester_cannot_update_project_status(self):
+        self.client.force_authenticate(user=self.tester_user)
+
+        response = self.client.patch(
+            self.url,
+            {'state': 'OPEN'},
+            format='json',
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.project.refresh_from_db()
+        self.assertEqual(self.project.state, 'PENDING')
+
+    def test_anonymous_user_cannot_update_project_status(self):
+        response = self.client.patch(
+            self.url,
+            {'state': 'OPEN'},
+            format='json',
+        )
+
+        self.assertIn(
+            response.status_code,
+            [status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN],
+        )
+        self.project.refresh_from_db()
+        self.assertEqual(self.project.state, 'PENDING')
+
+    def test_admin_cannot_use_invalid_status(self):
+        self.client.force_authenticate(user=self.admin_user)
+
+        response = self.client.patch(
+            self.url,
+            {'state': 'COMPLETED'},
+            format='json',
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.project.refresh_from_db()
+        self.assertEqual(self.project.state, 'PENDING')
+
+    def test_processed_project_cannot_be_updated_again(self):
+        self.client.force_authenticate(user=self.admin_user)
+        self.project.state = 'OPEN'
+        self.project.save()
+
+        response = self.client.patch(
+            self.url,
+            {'state': 'REJECTED'},
+            format='json',
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.project.refresh_from_db()
+        self.assertEqual(self.project.state, 'OPEN')
+
+    def test_nonexistent_project_returns_not_found(self):
+        self.client.force_authenticate(user=self.admin_user)
+        url = reverse('project-status-update', kwargs={'pk': 9999})
+
+        response = self.client.patch(url, {'state': 'OPEN'}, format='json')
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)

--- a/backend/apps/projects/urls.py
+++ b/backend/apps/projects/urls.py
@@ -1,8 +1,13 @@
 from django.urls import path
 
-from .views import ProjectCreateView
+from .views import ProjectCreateView, ProjectStatusUpdateView
 
 
 urlpatterns = [
     path('', ProjectCreateView.as_view(), name='project-create'),
+    path(
+        '<int:pk>/status/',
+        ProjectStatusUpdateView.as_view(),
+        name='project-status-update',
+    ),
 ]

--- a/backend/apps/projects/views.py
+++ b/backend/apps/projects/views.py
@@ -1,10 +1,11 @@
 from rest_framework import generics
+from rest_framework.exceptions import ValidationError
 from rest_framework.permissions import IsAuthenticated
 
-from apps.users.permissions import IsClient
+from apps.users.permissions import IsAdmin, IsClient
 
 from .models import Project
-from .serializers import ProjectSerializer
+from .serializers import ProjectSerializer, ProjectStatusSerializer
 
 
 class ProjectCreateView(generics.CreateAPIView):
@@ -14,3 +15,18 @@ class ProjectCreateView(generics.CreateAPIView):
 
     def perform_create(self, serializer):
         serializer.save(client=self.request.user)
+
+
+class ProjectStatusUpdateView(generics.UpdateAPIView):
+    queryset = Project.objects.all()
+    serializer_class = ProjectStatusSerializer
+    permission_classes = [IsAuthenticated, IsAdmin]
+    http_method_names = ['patch', 'options']
+
+    def perform_update(self, serializer):
+        if self.get_object().state != 'PENDING':
+            raise ValidationError(
+                {'state': 'Only pending projects can be approved or rejected.'}
+            )
+
+        serializer.save()


### PR DESCRIPTION
## Descripción

Implementa la aprobación y el rechazo de proyectos desde el backend.

## Funcionalidades

- Agrega el endpoint `PATCH /api/projects/<id>/status/`.
- Permite cambiar un proyecto pendiente a `OPEN` o `REJECTED`.
- Restringe la operación a usuarios autenticados con rol `ADMIN`.
- Impide modificar proyectos que ya fueron procesados.
- Valida estados no permitidos.
- Devuelve 404 cuando el proyecto no existe.

## Reglas de negocio

- Solo se pueden aprobar o rechazar proyectos con estado `PENDING`.
- Aprobar un proyecto cambia su estado a `OPEN`.
- Rechazar un proyecto cambia su estado a `REJECTED`.
- Solamente un administrador puede realizar estas operaciones.

## Pruebas

Se ejecutaron las pruebas de proyectos:
`python manage.py test apps.projects.tests`

